### PR TITLE
Add volunteer call-to-action component to all pages

### DIFF
--- a/src/app/pre-ecmc/pre-ecmc.component.html
+++ b/src/app/pre-ecmc/pre-ecmc.component.html
@@ -6,6 +6,7 @@
     <div class="content">
         <app-start id="start"></app-start>
         <app-stoerer-awareness-guide></app-stoerer-awareness-guide>
+        <app-helfer></app-helfer>
 
         <app-anmeldung></app-anmeldung>
         <!-- <app-programm-pre-ecmc></app-programm-pre-ecmc> -->

--- a/src/app/pre-ecmc/pre-ecmc.component.ts
+++ b/src/app/pre-ecmc/pre-ecmc.component.ts
@@ -10,11 +10,12 @@ import { VerhaltenComponent } from "../shared/verhalten/verhalten.component";
 import { SponsoringComponent } from "../shared/sponsoring/sponsoring.component";
 import { ProgrammPreEcmcComponent } from "./programm-pre-ecmc/programm-pre-ecmc.component";
 import { InstagramComponent } from "../shared/instagram/instagram.component";
+import { HelferComponent } from "../shared/helfer/helfer.component";
 
 @Component({
     selector: "app-pre-ecmc",
     standalone: true,
-    imports: [CommonModule, StartComponent, AnmeldungComponent, UnserVereinComponent, FooterComponent, SupportUsComponent, StoererAwarenessGuideComponent, ProgrammPreEcmcComponent, SponsoringComponent, InstagramComponent],
+    imports: [CommonModule, StartComponent, AnmeldungComponent, UnserVereinComponent, FooterComponent, SupportUsComponent, StoererAwarenessGuideComponent, HelferComponent, ProgrammPreEcmcComponent, SponsoringComponent, InstagramComponent],
     templateUrl: "./pre-ecmc.component.html",
     styleUrl: "./pre-ecmc.component.scss",
 })

--- a/src/app/sbpc/sbpc.component.html
+++ b/src/app/sbpc/sbpc.component.html
@@ -6,6 +6,7 @@
     <div class="content">
         <app-start id="start"></app-start>
         <app-stoerer-awareness-guide></app-stoerer-awareness-guide>
+        <app-helfer></app-helfer>
         <app-was-ist></app-was-ist>
         <app-anmeldung #anmeldung></app-anmeldung>
         <app-progamm-sbpc></app-progamm-sbpc>

--- a/src/app/sbpc/sbpc.component.ts
+++ b/src/app/sbpc/sbpc.component.ts
@@ -5,6 +5,7 @@ import { UnserVereinComponent } from "../shared/unser-verein/unser-verein.compon
 import { AnmeldungComponent } from "../shared/anmeldung/anmeldung.component";
 import { FooterComponent } from "../shared/footer/footer.component";
 import { WasIstComponent } from "../shared/was-ist/was-ist.component";
+import { HelferComponent } from "../shared/helfer/helfer.component";
 import { SupportUsComponent } from "../shared/support-us/support-us.component";
 import { StoererAwarenessGuideComponent } from "../shared/stoerer-awareness-guide/stoerer-awareness-guide.component";
 import { VerhaltenComponent } from "../shared/verhalten/verhalten.component";
@@ -18,7 +19,7 @@ import { InstagramComponent } from "../shared/instagram/instagram.component";
 @Component({
     selector: "app-sbpc",
     standalone: true,
-    imports: [CommonModule, StartComponent, AnmeldungComponent, UnserVereinComponent, FooterComponent, WasIstComponent, SupportUsComponent, StoererAwarenessGuideComponent, ProgammSbpcComponent, SponsoringComponent, RegistrationSbpcComponent, KarteComponent, LineupComponent, InstagramComponent],
+    imports: [CommonModule, StartComponent, AnmeldungComponent, UnserVereinComponent, FooterComponent, WasIstComponent, HelferComponent, SupportUsComponent, StoererAwarenessGuideComponent, ProgammSbpcComponent, SponsoringComponent, RegistrationSbpcComponent, KarteComponent, LineupComponent, InstagramComponent],
     templateUrl: "./sbpc.component.html",
     styleUrl: "./sbpc.component.scss",
 })

--- a/src/app/shared/helfer/helfer.component.html
+++ b/src/app/shared/helfer/helfer.component.html
@@ -1,0 +1,25 @@
+<section
+    [ngStyle]="{
+        'background-color': currentRoute === 'suicmc' ? '#2b61d9' : currentRoute === 'sbpc' ? '#622a9b' : currentRoute === 'pre ecmc' ? '#d86c00' : 'white'
+    }"
+>
+    <div
+        class="inlay"
+        [ngStyle]="{
+            color: currentRoute === 'suicmc' ? '#DEEEFF' : currentRoute === 'sbpc' ? '#EEDDFF' : currentRoute === 'pre ecmc' ? '#FDE9D5' : 'white'
+        }"
+    >
+        <h2>{{ getText('titel') }}</h2>
+
+        <div class="text-box">
+            <p>{{ getText('intro') }}</p>
+            <ul>
+                <li *ngFor="let item of getList()">{{ item }}</li>
+            </ul>
+            <p>
+                {{ getText('outro') }}
+                <a [href]="link" target="_blank">{{ link }}</a>
+            </p>
+        </div>
+    </div>
+</section>

--- a/src/app/shared/helfer/helfer.component.scss
+++ b/src/app/shared/helfer/helfer.component.scss
@@ -1,0 +1,11 @@
+@import '../../../styles.scss';
+
+section{
+    margin: 0;
+    width: 100%;
+    height: auto;
+    display: flex;
+    justify-content: center;
+
+
+}

--- a/src/app/shared/helfer/helfer.component.spec.ts
+++ b/src/app/shared/helfer/helfer.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { HelferComponent } from './helfer.component';
+
+describe('HelferComponent', () => {
+  let component: HelferComponent;
+  let fixture: ComponentFixture<HelferComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HelferComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(HelferComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/helfer/helfer.component.ts
+++ b/src/app/shared/helfer/helfer.component.ts
@@ -1,0 +1,82 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
+import { NavigationService } from '../../services/navigation.service';
+
+// Erstelle einen Union-Typ für die zulässigen Routen
+type RouteType = 'suicmc' | 'sbpc' | 'pre ecmc';
+
+@Component({
+  selector: 'app-helfer',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './helfer.component.html',
+  styleUrl: './helfer.component.scss'
+})
+export class HelferComponent implements OnInit {
+
+  currentRoute: RouteType = 'suicmc'; // Standardwert mit spezifischem Typ
+  currentLanguage: 'de' | 'en' = 'de';  // Standardwert für die Sprache
+
+  constructor(private navigationService: NavigationService) {}
+
+  text = {
+    helfer: {
+      titel: {
+        de: 'Dieser Event ist nur dank euch Helfer*innen möglich!',
+        en: 'This event is only possible thanks to all of you amazing volunteers!'
+      },
+      intro: {
+        de: 'Damit wir gemeinsam ein unvergessliches und reibungsloses Wochenende feiern können, sind wir weiterhin auf der Suche nach engagierten Helfer*innen. Als Helfer*in erhältst du:',
+        en: 'To make this weekend unforgettable and run smoothly, we’re still looking for dedicated volunteers to join our team. As a volunteer, you’ll get:'
+      },
+      items: {
+        de: [
+          'Verpflegung während des Wochenendes',
+          'Getränke zu vergünstigten Preisen',
+          'Gratis Eintritt zur Party in der Grabenhalle'
+        ],
+        en: [
+          'Free meals throughout the weekend',
+          'Drinks at reduced prices',
+          'Free entry to the party at Grabenhalle'
+        ]
+      },
+      outro: {
+        de: 'Wir freuen uns über jede Unterstützung – melde dich jetzt über diesen Link an!',
+        en: 'We’re grateful for any support – sign up now via this link:'
+      },
+      link: 'https://forms.gle/uUjmbuyNmEYhPHo78'
+    }
+  };
+
+  ngOnInit(): void {
+    // Abonniere den aktuellen Routenstatus
+    this.navigationService.currentRoute$.subscribe(route => {
+      const validRoute = route.toLowerCase() as RouteType;
+      if (validRoute) {
+        this.currentRoute = validRoute;
+      }
+    });
+
+    // Abonniere die aktuelle Sprache
+    this.navigationService.currentLanguage$.subscribe(language => {
+      const validLanguage = language.toLowerCase() as 'de' | 'en';
+      if (validLanguage) {
+        this.currentLanguage = validLanguage;
+      }
+    });
+  }
+
+  // Methoden, um Text oder Listen dynamisch abzurufen
+  getText(part: 'titel' | 'intro' | 'outro'): string {
+    return this.text.helfer[part][this.currentLanguage];
+  }
+
+  getList(): string[] {
+    return this.text.helfer.items[this.currentLanguage];
+  }
+
+  get link(): string {
+    return this.text.helfer.link;
+  }
+}

--- a/src/app/suicmc/suicmc.component.html
+++ b/src/app/suicmc/suicmc.component.html
@@ -6,6 +6,7 @@
     <div class="content" #contentContainer>
         <app-start id="start"></app-start>
         <app-stoerer-awareness-guide></app-stoerer-awareness-guide>
+        <app-helfer></app-helfer>
         <app-was-ist></app-was-ist>
         <app-anmeldung></app-anmeldung>
         <app-programm></app-programm>

--- a/src/app/suicmc/suicmc.component.ts
+++ b/src/app/suicmc/suicmc.component.ts
@@ -5,6 +5,7 @@ import { UnserVereinComponent } from "../shared/unser-verein/unser-verein.compon
 import { AnmeldungComponent } from "../shared/anmeldung/anmeldung.component";
 import { FooterComponent } from "../shared/footer/footer.component";
 import { WasIstComponent } from "../shared/was-ist/was-ist.component";
+import { HelferComponent } from "../shared/helfer/helfer.component";
 import { SupportUsComponent } from "../shared/support-us/support-us.component";
 import { filter } from "rxjs/operators";
 import { Router, NavigationEnd, ActivatedRoute } from "@angular/router";
@@ -20,7 +21,7 @@ import { InstagramComponent } from "../shared/instagram/instagram.component";
 @Component({
     selector: "app-suicmc",
     standalone: true,
-    imports: [CommonModule, StartComponent, AnmeldungComponent, UnserVereinComponent, FooterComponent, WasIstComponent, SupportUsComponent, StoererAwarenessGuideComponent, ProgrammComponent, SponsoringComponent, KarteComponent, LineupComponent, InstagramComponent],
+    imports: [CommonModule, StartComponent, AnmeldungComponent, UnserVereinComponent, FooterComponent, WasIstComponent, HelferComponent, SupportUsComponent, StoererAwarenessGuideComponent, ProgrammComponent, SponsoringComponent, KarteComponent, LineupComponent, InstagramComponent],
     templateUrl: "./suicmc.component.html",
     styleUrls: ["./suicmc.component.scss"],
 })


### PR DESCRIPTION
## Summary
- add new Helfer component modeled on WasIst to recruit volunteers
- insert Helfer block in SUICMC, SBPC and PRE ECMC pages
- register Helfer component in page imports

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_6898b09c6124832494c25ddc058f0f99