### PR TITLE
feat: add infrastructure locations component

### DIFF
--- a/src/app/pre-ecmc/pre-ecmc.component.html
+++ b/src/app/pre-ecmc/pre-ecmc.component.html
@@ -10,6 +10,7 @@
 
         <app-anmeldung></app-anmeldung>
         <app-programm-pre-ecmc></app-programm-pre-ecmc>
+        <app-infrastruktur-locations></app-infrastruktur-locations>
 
         <app-support-us></app-support-us>
         <app-unser-verein></app-unser-verein>

--- a/src/app/pre-ecmc/pre-ecmc.component.ts
+++ b/src/app/pre-ecmc/pre-ecmc.component.ts
@@ -11,11 +11,12 @@ import { SponsoringComponent } from "../shared/sponsoring/sponsoring.component";
 import { ProgrammPreEcmcComponent } from "./programm-pre-ecmc/programm-pre-ecmc.component";
 import { InstagramComponent } from "../shared/instagram/instagram.component";
 import { HelferComponent } from "../shared/helfer/helfer.component";
+import { InfrastrukturLocationsComponent } from "../shared/infrastruktur-locations/infrastruktur-locations.component";
 
 @Component({
     selector: "app-pre-ecmc",
     standalone: true,
-    imports: [CommonModule, StartComponent, AnmeldungComponent, UnserVereinComponent, FooterComponent, SupportUsComponent, StoererAwarenessGuideComponent, HelferComponent, ProgrammPreEcmcComponent, SponsoringComponent, InstagramComponent],
+    imports: [CommonModule, StartComponent, AnmeldungComponent, UnserVereinComponent, FooterComponent, SupportUsComponent, StoererAwarenessGuideComponent, HelferComponent, ProgrammPreEcmcComponent, InfrastrukturLocationsComponent, SponsoringComponent, InstagramComponent],
     templateUrl: "./pre-ecmc.component.html",
     styleUrl: "./pre-ecmc.component.scss",
 })

--- a/src/app/sbpc/sbpc.component.html
+++ b/src/app/sbpc/sbpc.component.html
@@ -10,6 +10,7 @@
         <app-was-ist></app-was-ist>
         <app-anmeldung #anmeldung></app-anmeldung>
         <app-progamm-sbpc></app-progamm-sbpc>
+        <app-infrastruktur-locations></app-infrastruktur-locations>
         <app-karte></app-karte>
         <app-lineup></app-lineup>
         <app-support-us></app-support-us>

--- a/src/app/sbpc/sbpc.component.ts
+++ b/src/app/sbpc/sbpc.component.ts
@@ -15,11 +15,12 @@ import { RegistrationSbpcComponent } from "./registration-sbpc/registration-sbpc
 import { KarteComponent } from "../shared/karte/karte.component";
 import { LineupComponent } from "../shared/lineup/lineup.component";
 import { InstagramComponent } from "../shared/instagram/instagram.component";
+import { InfrastrukturLocationsComponent } from "../shared/infrastruktur-locations/infrastruktur-locations.component";
 
 @Component({
     selector: "app-sbpc",
     standalone: true,
-    imports: [CommonModule, StartComponent, AnmeldungComponent, UnserVereinComponent, FooterComponent, WasIstComponent, HelferComponent, SupportUsComponent, StoererAwarenessGuideComponent, ProgammSbpcComponent, SponsoringComponent, RegistrationSbpcComponent, KarteComponent, LineupComponent, InstagramComponent],
+    imports: [CommonModule, StartComponent, AnmeldungComponent, UnserVereinComponent, FooterComponent, WasIstComponent, HelferComponent, SupportUsComponent, StoererAwarenessGuideComponent, ProgammSbpcComponent, InfrastrukturLocationsComponent, SponsoringComponent, RegistrationSbpcComponent, KarteComponent, LineupComponent, InstagramComponent],
     templateUrl: "./sbpc.component.html",
     styleUrl: "./sbpc.component.scss",
 })

--- a/src/app/shared/infrastruktur-locations/infrastruktur-locations.component.html
+++ b/src/app/shared/infrastruktur-locations/infrastruktur-locations.component.html
@@ -1,0 +1,33 @@
+<section
+    [ngClass]="{
+        suicmc: currentRoute === 'suicmc',
+        sbpc: currentRoute === 'sbpc',
+        'pre-ecmc': currentRoute === 'pre ecmc'
+    }"
+>
+    <div class="inlay">
+        <div class="title-box">
+            <h2>
+                {{
+                    currentLanguage === 'de'
+                        ? 'Informationen über Zugänglichkeit und Infrastruktur der Locations'
+                        : 'Information About Accessibility and Infrastructure'
+                }}
+            </h2>
+        </div>
+
+        <mat-accordion>
+            <mat-expansion-panel *ngFor="let location of locations">
+                <mat-expansion-panel-header>
+                    <mat-panel-title>{{ location.label[currentLanguage] }}</mat-panel-title>
+                </mat-expansion-panel-header>
+
+                <div class="ac-text">
+                    <ng-container *ngFor="let line of location.text[currentLanguage].split('\n')">
+                        <p>{{ line }}</p>
+                    </ng-container>
+                </div>
+            </mat-expansion-panel>
+        </mat-accordion>
+    </div>
+</section>

--- a/src/app/shared/infrastruktur-locations/infrastruktur-locations.component.scss
+++ b/src/app/shared/infrastruktur-locations/infrastruktur-locations.component.scss
@@ -1,0 +1,114 @@
+@import "../../../styles.scss";
+
+section.suicmc {
+    background-color: #437cfa;
+
+    .inlay {
+        color: #deeeff;
+
+        mat-accordion {
+            color: #deeeff;
+        }
+
+        mat-expansion-panel {
+            border-top: 1px solid $suicmc-blau-01;
+
+            &:last-child {
+                border-bottom: 1px solid $suicmc-blau-01;
+            }
+        }
+
+        mat-panel-title {
+            color: $suicmc-blau-01;
+        }
+        .ac-text {
+            color: $suicmc-blau-01;
+        }
+    }
+}
+
+section.sbpc {
+    background-color: #9343e3;
+
+    .inlay {
+        color: #eeddff;
+
+        mat-accordion {
+            color: #eeddff;
+        }
+        mat-expansion-panel {
+            border-top: 1px solid $sbpc-violett-01;
+
+            &:last-child {
+                border-bottom: 1px solid $sbpc-violett-01;
+            }
+        }
+
+        mat-panel-title {
+            color: $sbpc-violett-01;
+        }
+        .ac-text {
+            color: $sbpc-violett-01;
+        }
+    }
+}
+
+section.pre-ecmc {
+    background-color: #ff9021;
+
+    .inlay {
+        color: #fde9d5;
+
+        mat-accordion {
+            color: #fde9d5;
+        }
+        mat-expansion-panel {
+            border-top: 1px solid $pre-ecmc-light-apricot;
+
+            &:last-child {
+                border-bottom: 1px solid $pre-ecmc-light-apricot;
+            }
+        }
+
+        mat-panel-title {
+            color: $pre-ecmc-light-apricot;
+        }
+        .ac-text {
+            color: $pre-ecmc-light-apricot;
+        }
+    }
+}
+
+section {
+    margin: 0;
+    width: 100%;
+    height: auto;
+    display: flex;
+    justify-content: center;
+    background-color: grey;
+
+    > .inlay {
+        .text-box {
+            margin-bottom: 60px;
+        }
+
+        > mat-accordion {
+            width: 100%;
+
+            > mat-expansion-panel {
+                border-radius: 0px;
+                background-color: transparent !important;
+                width: 100%;
+
+                > mat-expansion-panel-header {
+                    font-family: $title-font;
+                    font-size: clamp(20px, 6vw, 30px);
+                }
+            }
+        }
+    }
+}
+
+.ac-text p {
+    margin: 2px 0;
+}

--- a/src/app/shared/infrastruktur-locations/infrastruktur-locations.component.spec.ts
+++ b/src/app/shared/infrastruktur-locations/infrastruktur-locations.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { InfrastrukturLocationsComponent } from './infrastruktur-locations.component';
+
+describe('InfrastrukturLocationsComponent', () => {
+  let component: InfrastrukturLocationsComponent;
+  let fixture: ComponentFixture<InfrastrukturLocationsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [InfrastrukturLocationsComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(InfrastrukturLocationsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/infrastruktur-locations/infrastruktur-locations.component.ts
+++ b/src/app/shared/infrastruktur-locations/infrastruktur-locations.component.ts
@@ -1,0 +1,159 @@
+import { Component } from "@angular/core";
+import { MatExpansionModule } from "@angular/material/expansion";
+import { ChangeDetectionStrategy } from "@angular/core";
+import { NavigationService } from "../../services/navigation.service";
+import { CommonModule } from "@angular/common";
+
+// Erstelle einen Union-Typ für die zulässigen Routen
+type RouteType = "suicmc" | "sbpc" | "pre ecmc";
+
+@Component({
+    selector: "app-infrastruktur-locations",
+    standalone: true,
+    imports: [CommonModule, MatExpansionModule],
+    templateUrl: "./infrastruktur-locations.component.html",
+    styleUrl: "./infrastruktur-locations.component.scss",
+    changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class InfrastrukturLocationsComponent {
+    currentRoute: RouteType = "suicmc"; // Standardwert mit spezifischem Typ
+    currentLanguage: "de" | "en" = "de"; // Standardwert für die Sprache
+
+    constructor(private navigationService: NavigationService) {}
+
+    ngOnInit(): void {
+        // Abonniere den aktuellen Routenstatus
+        this.navigationService.currentRoute$.subscribe((route) => {
+            const validRoute = route.toLowerCase() as RouteType;
+            if (validRoute) {
+                this.currentRoute = validRoute;
+            }
+        });
+
+        // Abonniere die aktuelle Sprache
+        this.navigationService.currentLanguage$.subscribe((language) => {
+            const validLanguage = language.toLowerCase() as "de" | "en";
+            if (validLanguage) {
+                this.currentLanguage = validLanguage;
+            }
+        });
+    }
+
+    locations = [
+        {
+            label: { de: "Areal Bürgli", en: "Areal Bürgli" },
+            text: {
+                de: `- erhöhte Lautstärke (Musik, Ballschläge, Mikrofon, Menschenmenge etc.)
+- keine rollstuhlgängige Toilette direkt in der Nähe, 400 m zum Festareal Theater
+- 2-3 erhöhte Plätze für Rollstühle auf Tribüne verfügbar
+- enge Platzverhältnisse rund ums Spielfeld
+- Essen und Getränke
+- Sanität`,
+                en: `- Elevated volume (music, ball impacts, microphone, crowds, etc.)
+- No wheelchair accesible toilet nearby (approx. 400 m to Festival Area – Theater)
+- 2-3 elevated spaces on the grandstand available for wheelchairs
+- Tight spaces around the playing field
+- Food and drinks
+- First aid on site`,
+            },
+        },
+        {
+            label: { de: "Dreilinden", en: "Dreilinden" },
+            text: {
+                de: `- Start: keine Überdachung/Sonnenschutz, keine Toiletten, Sitzmöglichkeitenbeschränkt vorhanden
+- Ziel: stufenlos, Innenbereich mit Musik und Stroboskop, Aussenbereich vorhanden
+- öffentliche Toilette (nicht rollstuhlgängig) 100 m aufwärts vom Zielbereich entfernt,
+- Sitzmöglichkeiten beschränkt vorhanden`,
+                en: `- Start area: No shelter or sun protection, no toilets, limited seating
+- Finish area: Step-free access, indoor area with music and strobe lights
+- Outdoor area with a public toilet (not wheelchair accessible) approx. 100 m uphill away
+- Limited seating available`,
+            },
+        },
+        {
+            label: { de: "Areal Theater", en: "Areal Theater" },
+            text: {
+                de: `- Erhöhte Lautstärke (Musik, Megafone, Menschenmenge etc.)
+- Areal stufenlos, teilweise Trottoirs, rollstuhlgängige Toilette
+- Sanität
+- Essen und Getränke
+- Kinder Laufradolympiade
+- Safer Space`,
+                en: `- Elevated volume (music, megaphones, crowds, etc.)
+- Step-free access across the area, some sidewalks
+- Wheelchair-accessible toilet available
+- First aid on site
+- Food and drinks
+- Kids’ bike competition
+- Safer Space`,
+            },
+        },
+        {
+            label: { de: "Hermann Bier", en: "Hermann Bier" },
+            text: {
+                de: `- nicht barrierefrei > Treppe (5 Stufen) zum Lokal
+- Sitzplätze vorhanden`,
+                en: `- Not barrier-free – 5 steps to enter
+- Seating available`,
+            },
+        },
+        {
+            label: { de: "Grabenhalle", en: "Grabenhalle" },
+            text: {
+                de: `- stufenlos
+- rollstuhlgängige Toilette vorhanden
+- Innenbereich: erhöhte Lautstärke (Musik, Menschenmenge etc.), Gehörschutz vorhanden, Stroboskop, Sitzplätze vorhanden
+- Aussenbereich: Sitzplätze vorhanden
+- Safer Space`,
+                en: `- Step-free access
+- Wheelchair accessible toilet available
+- Indoor: Elevated volume (music, crowds), strobe lights, seating available
+- Outdoor area: Seating available
+- Safer Space`,
+            },
+        },
+        {
+            label: { de: "Schwarzer Engel", en: "Schwarzer Engel" },
+            text: {
+                de: `- stufenlos bis zum Barbereich, kurze Treppe zum restlichen Bereich
+- Toilette im Untergeschoss über Treppe
+- Innenbereich: erhöhte Lautstärke, Sitzplätze vorhanden
+- Aussenbereich: Sitzplätze vorhanden
+- Safer Space`,
+                en: `- Step-free access to barber area, short staircase to the rest of the venue
+- Toilet in basement, accessible only by stairs
+- Indoor: Elevated volume, seating available
+- Outdoor: Seating available
+- Safer Space`,
+            },
+        },
+        {
+            label: { de: "Housing 1 WTNB", en: "Housing 1 WTNB" },
+            text: {
+                de: `- nicht barrierefrei
+- Veloparkplatz im Eingangsbereich (Indoor)`,
+                en: `- Not barrier-free
+- Indoor bike parking at entrance`,
+            },
+        },
+        {
+            label: { de: "Housing 2 OPEN", en: "Housing 2 OPEN" },
+            text: {
+                de: `- nicht barrierefrei
+- Veloparkplatz im Eingangsbereich (Outdoor)`,
+                en: `- Not barrier-free
+- Outdoor bike parking at entrance`,
+            },
+        },
+        {
+            label: { de: "Housing 3 OPEN / Camping", en: "Housing 3 OPEN / Camping" },
+            text: {
+                de: `- barrierefrei
+- Veloparkplatz (Outdoor)`,
+                en: `- Barrier-free
+- Outdoor bike parking`,
+            },
+        },
+    ];
+}
+

--- a/src/app/shared/infrastruktur-locations/infrastruktur-locations.component.ts
+++ b/src/app/shared/infrastruktur-locations/infrastruktur-locations.component.ts
@@ -1,6 +1,5 @@
 import { Component } from "@angular/core";
 import { MatExpansionModule } from "@angular/material/expansion";
-import { ChangeDetectionStrategy } from "@angular/core";
 import { NavigationService } from "../../services/navigation.service";
 import { CommonModule } from "@angular/common";
 
@@ -13,7 +12,6 @@ type RouteType = "suicmc" | "sbpc" | "pre ecmc";
     imports: [CommonModule, MatExpansionModule],
     templateUrl: "./infrastruktur-locations.component.html",
     styleUrl: "./infrastruktur-locations.component.scss",
-    changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class InfrastrukturLocationsComponent {
     currentRoute: RouteType = "suicmc"; // Standardwert mit spezifischem Typ

--- a/src/app/suicmc/suicmc.component.html
+++ b/src/app/suicmc/suicmc.component.html
@@ -10,6 +10,7 @@
         <app-was-ist></app-was-ist>
         <app-anmeldung></app-anmeldung>
         <app-programm></app-programm>
+        <app-infrastruktur-locations></app-infrastruktur-locations>
         <app-karte></app-karte>
         <app-lineup></app-lineup>
         <app-support-us></app-support-us>

--- a/src/app/suicmc/suicmc.component.ts
+++ b/src/app/suicmc/suicmc.component.ts
@@ -14,6 +14,7 @@ import { StoererAwarenessGuideComponent } from "../shared/stoerer-awareness-guid
 import { VerhaltenComponent } from "../shared/verhalten/verhalten.component";
 import { SponsoringComponent } from "../shared/sponsoring/sponsoring.component";
 import { ProgrammComponent } from "./programm/programm.component";
+import { InfrastrukturLocationsComponent } from "../shared/infrastruktur-locations/infrastruktur-locations.component";
 import { KarteComponent } from "../shared/karte/karte.component";
 import { LineupComponent } from "../shared/lineup/lineup.component";
 import { InstagramComponent } from "../shared/instagram/instagram.component";
@@ -21,7 +22,7 @@ import { InstagramComponent } from "../shared/instagram/instagram.component";
 @Component({
     selector: "app-suicmc",
     standalone: true,
-    imports: [CommonModule, StartComponent, AnmeldungComponent, UnserVereinComponent, FooterComponent, WasIstComponent, HelferComponent, SupportUsComponent, StoererAwarenessGuideComponent, ProgrammComponent, SponsoringComponent, KarteComponent, LineupComponent, InstagramComponent],
+    imports: [CommonModule, StartComponent, AnmeldungComponent, UnserVereinComponent, FooterComponent, WasIstComponent, HelferComponent, SupportUsComponent, StoererAwarenessGuideComponent, ProgrammComponent, InfrastrukturLocationsComponent, SponsoringComponent, KarteComponent, LineupComponent, InstagramComponent],
     templateUrl: "./suicmc.component.html",
     styleUrls: ["./suicmc.component.scss"],
 })


### PR DESCRIPTION
## Summary
- add shared infrastructure-locations accordion with accessibility details
- show infrastructure component on SUICMC, SBPC and PRE-ECMC pages

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_6898c1e0d21883249c5878b2c03cc220