### PR TITLE
feat: add housing section with route-based styling

### DIFF
--- a/src/app/pre-ecmc/pre-ecmc.component.html
+++ b/src/app/pre-ecmc/pre-ecmc.component.html
@@ -7,12 +7,14 @@
         <app-start id="start"></app-start>
         <app-stoerer-awareness-guide></app-stoerer-awareness-guide>
         <app-stoerer-sport-inklusiv></app-stoerer-sport-inklusiv>
-        <app-helfer></app-helfer>
-
+        <app-was-ist></app-was-ist>
         <app-anmeldung></app-anmeldung>
+        <app-helfer></app-helfer>
         <app-programm-pre-ecmc></app-programm-pre-ecmc>
+        <app-karte></app-karte>
         <app-infrastruktur-locations></app-infrastruktur-locations>
-
+        <app-housing></app-housing>
+        <app-lineup></app-lineup>
         <app-support-us></app-support-us>
         <app-unser-verein></app-unser-verein>
         <!-- <app-verhalten></app-verhalten> -->

--- a/src/app/pre-ecmc/pre-ecmc.component.ts
+++ b/src/app/pre-ecmc/pre-ecmc.component.ts
@@ -13,11 +13,15 @@ import { ProgrammPreEcmcComponent } from "./programm-pre-ecmc/programm-pre-ecmc.
 import { InstagramComponent } from "../shared/instagram/instagram.component";
 import { HelferComponent } from "../shared/helfer/helfer.component";
 import { InfrastrukturLocationsComponent } from "../shared/infrastruktur-locations/infrastruktur-locations.component";
+import { WasIstComponent } from "../shared/was-ist/was-ist.component";
+import { KarteComponent } from "../shared/karte/karte.component";
+import { LineupComponent } from "../shared/lineup/lineup.component";
+import { HousingComponent } from "../shared/housing/housing.component";
 
 @Component({
     selector: "app-pre-ecmc",
     standalone: true,
-    imports: [CommonModule, StartComponent, AnmeldungComponent, UnserVereinComponent, FooterComponent, SupportUsComponent, StoererAwarenessGuideComponent, StoererSportInklusivComponent, HelferComponent, ProgrammPreEcmcComponent, InfrastrukturLocationsComponent, SponsoringComponent, InstagramComponent],
+    imports: [CommonModule, StartComponent, AnmeldungComponent, UnserVereinComponent, FooterComponent, SupportUsComponent, StoererAwarenessGuideComponent, StoererSportInklusivComponent, WasIstComponent, HelferComponent, ProgrammPreEcmcComponent, KarteComponent, InfrastrukturLocationsComponent, HousingComponent, LineupComponent, SponsoringComponent, InstagramComponent],
     templateUrl: "./pre-ecmc.component.html",
     styleUrl: "./pre-ecmc.component.scss",
 })

--- a/src/app/sbpc/sbpc.component.html
+++ b/src/app/sbpc/sbpc.component.html
@@ -7,12 +7,13 @@
         <app-start id="start"></app-start>
         <app-stoerer-awareness-guide></app-stoerer-awareness-guide>
         <app-stoerer-sport-inklusiv></app-stoerer-sport-inklusiv>
-        <app-helfer></app-helfer>
         <app-was-ist></app-was-ist>
         <app-anmeldung #anmeldung></app-anmeldung>
+        <app-helfer></app-helfer>
         <app-progamm-sbpc></app-progamm-sbpc>
-        <app-infrastruktur-locations></app-infrastruktur-locations>
         <app-karte></app-karte>
+        <app-infrastruktur-locations></app-infrastruktur-locations>
+        <app-housing></app-housing>
         <app-lineup></app-lineup>
         <app-support-us></app-support-us>
         <app-unser-verein></app-unser-verein>

--- a/src/app/sbpc/sbpc.component.ts
+++ b/src/app/sbpc/sbpc.component.ts
@@ -17,11 +17,12 @@ import { KarteComponent } from "../shared/karte/karte.component";
 import { LineupComponent } from "../shared/lineup/lineup.component";
 import { InstagramComponent } from "../shared/instagram/instagram.component";
 import { InfrastrukturLocationsComponent } from "../shared/infrastruktur-locations/infrastruktur-locations.component";
+import { HousingComponent } from "../shared/housing/housing.component";
 
 @Component({
     selector: "app-sbpc",
     standalone: true,
-    imports: [CommonModule, StartComponent, AnmeldungComponent, UnserVereinComponent, FooterComponent, WasIstComponent, HelferComponent, SupportUsComponent, StoererAwarenessGuideComponent, StoererSportInklusivComponent, ProgammSbpcComponent, InfrastrukturLocationsComponent, SponsoringComponent, RegistrationSbpcComponent, KarteComponent, LineupComponent, InstagramComponent],
+    imports: [CommonModule, StartComponent, AnmeldungComponent, UnserVereinComponent, FooterComponent, WasIstComponent, HelferComponent, SupportUsComponent, StoererAwarenessGuideComponent, StoererSportInklusivComponent, ProgammSbpcComponent, KarteComponent, InfrastrukturLocationsComponent, HousingComponent, SponsoringComponent, RegistrationSbpcComponent, LineupComponent, InstagramComponent],
     templateUrl: "./sbpc.component.html",
     styleUrl: "./sbpc.component.scss",
 })

--- a/src/app/shared/housing/housing.component.html
+++ b/src/app/shared/housing/housing.component.html
@@ -1,0 +1,21 @@
+<section
+    [ngStyle]="{
+        'background-color': currentRoute === 'suicmc' ? '#2b61d9' : currentRoute === 'sbpc' ? '#622a9b' : currentRoute === 'pre ecmc' ? '#d86c00' : 'white'
+    }"
+>
+    <div class="inlay">
+        <div class="title-box">
+            <h2>{{ text.title[currentLanguage] }}</h2>
+        </div>
+        <div class="text-box" [innerHTML]="text.intro[currentLanguage]"></div>
+
+        <mat-accordion>
+            <mat-expansion-panel *ngFor="let item of text.items">
+                <mat-expansion-panel-header>
+                    <mat-panel-title>{{ item.label[currentLanguage] }}</mat-panel-title>
+                </mat-expansion-panel-header>
+                <div class="ac-text" [innerHTML]="item.text[currentLanguage]"></div>
+            </mat-expansion-panel>
+        </mat-accordion>
+    </div>
+</section>

--- a/src/app/shared/housing/housing.component.scss
+++ b/src/app/shared/housing/housing.component.scss
@@ -9,8 +9,8 @@ section {
     color: #fff;
 
     > .inlay {
-        width: min(800px, 100%);
-        padding: 60px 20px;
+        // width: min(800px, 100%);
+        // padding: 60px 20px;
 
         .text-box {
             margin-bottom: 60px;
@@ -20,6 +20,7 @@ section {
             width: 100%;
 
             mat-expansion-panel {
+                color: #fff;
                 border-radius: 0;
                 background-color: transparent !important;
 
@@ -34,4 +35,8 @@ section {
 
 .ac-text p {
     margin: 2px 0;
+}
+
+mat-panel-title {
+    color: #fff;
 }

--- a/src/app/shared/housing/housing.component.scss
+++ b/src/app/shared/housing/housing.component.scss
@@ -1,0 +1,37 @@
+@import "../../../styles.scss";
+
+section {
+    margin: 0;
+    width: 100%;
+    height: auto;
+    display: flex;
+    justify-content: center;
+    color: #fff;
+
+    > .inlay {
+        width: min(800px, 100%);
+        padding: 60px 20px;
+
+        .text-box {
+            margin-bottom: 60px;
+        }
+
+        mat-accordion {
+            width: 100%;
+
+            mat-expansion-panel {
+                border-radius: 0;
+                background-color: transparent !important;
+
+                mat-expansion-panel-header {
+                    font-family: $title-font;
+                    font-size: clamp(20px, 6vw, 30px);
+                }
+            }
+        }
+    }
+}
+
+.ac-text p {
+    margin: 2px 0;
+}

--- a/src/app/shared/housing/housing.component.spec.ts
+++ b/src/app/shared/housing/housing.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { HousingComponent } from './housing.component';
+
+describe('HousingComponent', () => {
+  let component: HousingComponent;
+  let fixture: ComponentFixture<HousingComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HousingComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(HousingComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/housing/housing.component.ts
+++ b/src/app/shared/housing/housing.component.ts
@@ -1,0 +1,98 @@
+import { Component } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import { MatExpansionModule } from "@angular/material/expansion";
+import { NavigationService } from "../../services/navigation.service";
+
+// Erstelle einen Union-Typ für die zulässigen Routen
+type RouteType = "suicmc" | "sbpc" | "pre ecmc";
+
+@Component({
+    selector: "app-housing",
+    standalone: true,
+    imports: [CommonModule, MatExpansionModule],
+    templateUrl: "./housing.component.html",
+    styleUrl: "./housing.component.scss",
+})
+export class HousingComponent {
+    currentRoute: RouteType = "suicmc";
+    currentLanguage: "de" | "en" = "de";
+
+    constructor(private navigationService: NavigationService) {}
+
+    ngOnInit(): void {
+        this.navigationService.currentRoute$.subscribe((route) => {
+            const validRoute = route.toLowerCase() as RouteType;
+            if (validRoute) {
+                this.currentRoute = validRoute;
+            }
+        });
+
+        this.navigationService.currentLanguage$.subscribe((language) => {
+            const validLanguage = language.toLowerCase() as "de" | "en";
+            if (validLanguage) {
+                this.currentLanguage = validLanguage;
+            }
+        });
+    }
+
+    text = {
+        title: { de: "Housing", en: "Housing" },
+        intro: {
+            de: `Wir bemühen uns, gerade beim Camping, dass die Housings
+durchgängig mit Personal bewacht werden. Vor allem fürs Open Housing 2 aber
+grundsätzlich für alle haben wir 2 Garderoben inkl. Grossraumduschen im Athletik
+Zentrum St. Gallen. Dieses befindet sich auf dem Mainrace-Areal und ist Samstag und
+Sonntag von 07 – 19 Uhr geöffnet.<br><br>Die Gebühr für das Housing bitte direkt mit der Registrationsgebühr überweisen. Vielen Dank.`,
+            en: `We make every effort, especially for the camping options, to
+ensure that all housing areas are continuously monitored by staff.
+Particularly for Open Housing 2, but in general available to everyone, we provide access
+to 2 changing rooms with large communal showers at the Athletics Center St. Gallen.
+This facility is located on the Mainrace grounds and is open on Saturday and Sunday
+from 07:00 to 19:00.<br><br>Please transfer the housing fee together with the registration fee. Thank you!`,
+        },
+        items: [
+            {
+                label: { de: "Housing 1 WTNB / CHF 5", en: "Housing 1 WTNB / CHF 5" },
+                text: {
+                    de: `Exklusiv für WTNB-Menschen, in einer Zivilschutzanlage im Untergrund (kein
+Tageslicht), wo sich rund 60 WTNB-Menschen auf 4 Gemeinschaftszimmer verteilen.<br><br>
+Insgesamt 3 Duschen, 1 Waschmöglichkeit sowie 5 Toiletten stehen zur Verfügung.
+Punkten kann die Anlage mit komfortablen Feldbetten und das dein Fahrrad ein Dach
+über dem Sattel hat.<br><br>
+Mitbringen: Seidenschlafsack`,
+                    en: `Exclusively for WTNB individuals, located in an underground civil defense shelter (no
+daylight), where around 60 WTNB people are accommodated across 4 shared rooms.<br><br>
+The facility offers 3 showers, 1 washing station, and 5 toilets. Highlights include
+comfortable camp beds and a covered space for your bicycle.<br><br>
+What to bring: Silk sleeping bag`,
+                },
+            },
+            {
+                label: { de: "Housing 2 OPEN / CHF 5", en: "Housing 2 OPEN / CHF 5" },
+                text: {
+                    de: `In einer Lichtdurchflutteten Sporthalle, wo sich rund 100 Menschen denselben Raum
+teilen. Insgesamt 2 Grossraumduschen und 5 Gemeinschaftstoiletten stehen zur
+Verfügung.<br><br>
+Mitbringen: Mätteli, Schlafsack`,
+                    en: `In a bright and sunlit sports hall, where around 100 people share the same space. The
+facility provides 2 large communal showers and 5 shared toilets.<br><br>
+What to bring: Sleeping mat, sleeping bag`,
+                },
+            },
+            {
+                label: { de: "Housing 3 OPEN Camping / CHF 5", en: "Housing 3 OPEN Camping / CHF 5" },
+                text: {
+                    de: `Auf rund 300m2 steht dir im Zentrum der Stadt St. Gallen eine Wiese mit angrenzendem
+Parkplatz zur Verfügung. Umzäunt von Gittern kommt hier etwas Festivalfeeling auf.
+Insgesamt 3 Toiletten, 1 Waschmöglichkeit jedoch keine Dusche stehen zur Verfügung.<br><br>
+Mitbringen: Zelt, Mätteli, Schlafsack oder dein Camper / Büssli`,
+                    en: `In the heart of St. Gallen, approx. 300 m² of meadow with an adjacent parking lot is
+available. Fenced in with barriers, this setup gives off a slight festival vibe. The facility
+offers 3 toilets, 1 washing station, but no shower.<br><br>
+What to bring: Tent, sleeping mat, sleeping bag or your camper van`,
+                },
+            },
+        ],
+    };
+}
+

--- a/src/app/shared/infrastruktur-locations/infrastruktur-locations.component.scss
+++ b/src/app/shared/infrastruktur-locations/infrastruktur-locations.component.scss
@@ -1,5 +1,9 @@
 @import "../../../styles.scss";
 
+h2 {
+    padding-bottom: 30px;
+}
+
 section.suicmc {
     background-color: #437cfa;
 

--- a/src/app/suicmc/suicmc.component.html
+++ b/src/app/suicmc/suicmc.component.html
@@ -13,7 +13,7 @@
         <app-programm></app-programm>
         <app-karte></app-karte>
         <app-infrastruktur-locations></app-infrastruktur-locations>
-        Hier die neue Housing component
+        <app-housing></app-housing>
         <app-lineup></app-lineup>
         <app-support-us></app-support-us>
         <app-unser-verein></app-unser-verein>

--- a/src/app/suicmc/suicmc.component.ts
+++ b/src/app/suicmc/suicmc.component.ts
@@ -19,11 +19,12 @@ import { InfrastrukturLocationsComponent } from "../shared/infrastruktur-locatio
 import { KarteComponent } from "../shared/karte/karte.component";
 import { LineupComponent } from "../shared/lineup/lineup.component";
 import { InstagramComponent } from "../shared/instagram/instagram.component";
+import { HousingComponent } from "../shared/housing/housing.component";
 
 @Component({
     selector: "app-suicmc",
     standalone: true,
-    imports: [CommonModule, StartComponent, AnmeldungComponent, UnserVereinComponent, FooterComponent, WasIstComponent, HelferComponent, SupportUsComponent, StoererAwarenessGuideComponent, StoererSportInklusivComponent, ProgrammComponent, InfrastrukturLocationsComponent, SponsoringComponent, KarteComponent, LineupComponent, InstagramComponent],
+    imports: [CommonModule, StartComponent, AnmeldungComponent, UnserVereinComponent, FooterComponent, WasIstComponent, HelferComponent, SupportUsComponent, StoererAwarenessGuideComponent, StoererSportInklusivComponent, ProgrammComponent, InfrastrukturLocationsComponent, HousingComponent, SponsoringComponent, KarteComponent, LineupComponent, InstagramComponent],
     templateUrl: "./suicmc.component.html",
     styleUrls: ["./suicmc.component.scss"],
 })


### PR DESCRIPTION
## Summary
- add shared housing component with accordion details and dynamic route colors
- insert housing block into SUICMC, SBPC, and PRE-ECMC pages and unify section order

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68a0bbbdbc108324944411d030fa7731